### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,41 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.9
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.9
+        - PLAT=i686
+    - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=aarch64
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=aarch64
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=aarch64
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.9
+        - PLAT=aarch64
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
     - os: osx
       language: generic
       env: MB_PYTHON_VERSION=2.7


### PR DESCRIPTION
Add linux aarch64 wheel build support. 

Related to https://github.com/MacPython/pyreadstat-wheels/issues/6